### PR TITLE
RESTAPI login request

### DIFF
--- a/htdocs/api/v0.0.1/APIBase.php
+++ b/htdocs/api/v0.0.1/APIBase.php
@@ -68,7 +68,7 @@ abstract class APIBase
         // Even though it's not a command line client, this prevents
         // the login related to showing the login screen from applying,
         // then we manually
-        $this->client->makeCommandLine();
+        //$this->client->makeCommandLine();
         $this->client->initialize(__DIR__ . "/../../../project/config.xml");
 
         if (!defined("UNIT_TESTING")) {


### PR DESCRIPTION
By creating the client to be commandLine it causes the client session to not be properly created and checked, causing all request to return a 401 Not Authorized 