### PR TITLE
[Fix] Rely on default index.php

### DIFF
--- a/docs/config/apache2-site
+++ b/docs/config/apache2-site
@@ -16,7 +16,7 @@
 
 	php_value include_path .:/usr/share/php:%LORISROOT%/project/libraries:%LORISROOT%/php/libraries
 
-	DirectoryIndex main.php index.html
+	#DirectoryIndex main.php index.html
 
 	ErrorLog %LOGDIRECTORY%/loris-error.log
 


### PR DESCRIPTION
Remove the entry for DirectoryIndex in the apache-conf file to rely on the default index.php to be loaded.

