### PR TITLE
Http Error class

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -173,6 +173,9 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
         $page = str_replace("-", "", $page);
 
         $className = "\LORIS\\" . $this->name . "\\$page";
+        if (!class_exists($className)) {
+            throw new \NotFound($className);
+        }
 
         $identifier = $_REQUEST['identifier'] ?? '';
         $commentID  = $_REQUEST['commentID'] ?? '';
@@ -216,20 +219,20 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
         if ($resp->getStatusCode() != 404) {
             return $resp;
         }
-        switch ($request->getURI()->getPath()) {
-        case "":
-        case "/":
-            $page = $this->loadPage($this->getName());
-            return $page->process($request, $page);
-        default:
-            // Fall back on the old way of doing subpages
-            $components = explode("@", trim($request->getURI()->getPath(), "/"));
-            $page       = $this->loadPage($components[0]);
-            return $page->process($request, $page);
+
+        $pagename = $this->getName();
+        $path     = trim($request->getURI()->getPath(), "/");
+        if (!empty($path)) {
+            // There is a subpage
+            $pagename = explode("@", $path)[0];
         }
 
-        return (new \Zend\Diactoros\Response())
-            ->withStatus(404)
-            ->withBody(new \LORIS\Http\StringStream("File not found: " . $request->getURI()->__toString()));
+        try {
+            $page = $this->loadPage($pagename);
+        } catch (\Notfound $e) {
+            return (new \LORIS\Http\Error($request, 404, "File not found: " . $request->getURI()->__toString()));
+        }
+
+        return $page->process($request, $page);
     }
 }

--- a/smarty/templates/403.tpl
+++ b/smarty/templates/403.tpl
@@ -1,4 +1,5 @@
 <div class="container">
     <h2>You do not have access to this page.</h2>
+    <h3>{$message}</h3>
     <div><a href="{$baseurl}">Go to login page</a></div>
 </div>

--- a/smarty/templates/404.tpl
+++ b/smarty/templates/404.tpl
@@ -1,4 +1,5 @@
 <div class="container">
     <h2>404: Page not found.</h2>
+    <h3>{$message}</h3>
     <a href="{$baseurl}">Go to login page</a></div>
 </div>

--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file implements a HTTP error, a simple wrapper which provide
+ * a html response using smarthy templates. It rely on the Diactoros implementation
+ * of the Response object to provide the reason phrase according to the status code.
+ *
+ * PHP Version 7
+ *
+ * @category PSR7
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecoursboucher@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ */
+namespace LORIS\Http;
+use \Zend\Diactoros\Response\HtmlResponse;
+use \Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * A html representation of a http error
+ *
+ * @category PSR7
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecoursboucher@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Error extends HtmlResponse
+{
+    /**
+     * Takes the value $val and converts it to a PSR7 StreamInterface.
+     *
+     * @param string $val The string value to convert to a stream.
+     */
+    public function __construct(ServerRequestInterface $request, int $status, string $message = '')
+    {
+        // TODO :: Extract baseurl from request. The '/' might break if the DirectoryRoot is different
+        $tpl_data = array(
+                     'message' => $message,
+                     'baseurl' => '/',
+                    );
+        $template_file = (string) $status . '.tpl';
+        $body          = (new \Smarty_neurodb())
+            ->assign($tpl_data)
+            ->fetch($template_file);
+
+        parent::__construct(
+            (new \LORIS\Http\StringStream($body)),
+            $status,
+            array()
+        );
+    }
+}

--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -63,10 +63,6 @@ class AuthMiddleware implements MiddlewareInterface, MiddlewareChainer
         if ($this->authenticator->authenticate($request) === true) {
             return $this->next->process($request, $handler);
         }
-        // FIXME: Use smarty template.
-        return (new \Zend\Diactoros\Response())
-           ->withStatus(403)
-          ->withBody(new \LORIS\Http\StringStream("Permission denied"));
-
+        return (new \LORIS\Http\Error($request, 403, "Permission denied"));
     }
 }

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -133,9 +133,6 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             }
         }
 
-        // FIXME: Use 404 from smarty template.
-        return (new \Zend\Diactoros\Response())
-            ->withStatus(404)
-            ->withBody(new StringStream("Not Found"));
+        return (new \LORIS\Http\Error($request, 404));
     }
 }

--- a/src/Router/PrefixRouter.php
+++ b/src/Router/PrefixRouter.php
@@ -100,10 +100,6 @@ class PrefixRouter implements RequestHandlerInterface
                 return $subhandler->handle($request);
             }
         }
-        return (new \Zend\Diactoros\Response())
-            ->withStatus(404)
-            ->withBody(
-                new StringStream("Not found")
-            );
+        return (new \LORIS\Http\Error($request, 404));
     }
 }


### PR DESCRIPTION
Add a class to handle http errors creating an html response using samrty template based on status code.

Should this be in src/Http/Response/ instead of src/Http/ ? 
Diactoros put the Response subclasses under Response.